### PR TITLE
Add GetMessageAsync to DiscordClient and GuildId to DiscordMessage

### DIFF
--- a/Miki.Discord.Common/Models/IDiscordMessage.cs
+++ b/Miki.Discord.Common/Models/IDiscordMessage.cs
@@ -7,30 +7,32 @@ namespace Miki.Discord.Common
 {
 	public interface IDiscordMessage : ISnowflake
 	{
-        /// <summary>
-        /// All attachments attached to this message.
-        /// </summary>
-        IReadOnlyList<IDiscordAttachment> Attachments { get; }
+		/// <summary>
+		/// All attachments attached to this message.
+		/// </summary>
+		IReadOnlyList<IDiscordAttachment> Attachments { get; }
 
-        /// <summary>
-        /// The creator of the message.
-        /// </summary>
-        IDiscordUser Author { get; }
+		/// <summary>
+		/// The creator of the message.
+		/// </summary>
+		IDiscordUser Author { get; }
 
-        string Content { get; }
+		string Content { get; }
 
-        /// <summary>
-        /// The channel this message was created in.
-        /// </summary>
+		ulong? GuildId { get; }
+
+		/// <summary>
+		/// The channel this message was created in.
+		/// </summary>
 		ulong ChannelId { get; }
 
-        IReadOnlyList<ulong> MentionedUserIds { get; }
+		IReadOnlyList<ulong> MentionedUserIds { get; }
 
-        DateTimeOffset Timestamp { get; }
+		DateTimeOffset Timestamp { get; }
 
-        MessageType Type { get; }
+		MessageType Type { get; }
 
-        Task CreateReactionAsync(DiscordEmoji emoji);
+		Task CreateReactionAsync(DiscordEmoji emoji);
 
 		Task DeleteReactionAsync(DiscordEmoji emoji);
 
@@ -42,9 +44,9 @@ namespace Miki.Discord.Common
 
 		Task<IDiscordMessage> EditAsync(EditMessageArgs args);
 
-        /// <summary>
-        /// Deletes this message.
-        /// </summary>
+		/// <summary>
+		/// Deletes this message.
+		/// </summary>
 		Task DeleteAsync();
 
 		Task<IDiscordTextChannel> GetChannelAsync();

--- a/Miki.Discord/DiscordClient.cs
+++ b/Miki.Discord/DiscordClient.cs
@@ -174,6 +174,12 @@ namespace Miki.Discord
 				embed = embed
 			});
 
+		public async Task<IDiscordMessage> GetMessageAsync(ulong channelId, ulong messageId)
+			=> new DiscordMessage(
+				await _apiClient.GetMessageAsync(channelId, messageId),
+				this
+			);
+
 		internal async Task<DiscordChannelPacket> GetChannelPacketAsync(ulong id, ulong? guildId)
 		{
 			DiscordChannelPacket packet = await CacheClient.HashGetAsync<DiscordChannelPacket>(CacheUtils.ChannelsKey(guildId), id.ToString());

--- a/Miki.Discord/Internal/DiscordMessage.cs
+++ b/Miki.Discord/Internal/DiscordMessage.cs
@@ -32,6 +32,9 @@ namespace Miki.Discord.Internal
 		public ulong ChannelId
 			=> _packet.ChannelId;
 
+		public ulong? GuildId
+			=> _packet.GuildId;
+
 		public IReadOnlyList<ulong> MentionedUserIds
 			=> _packet.Mentions.Select(x => x.Id).ToList();
 


### PR DESCRIPTION
- `DiscordClient.GetMessageAsync` is a method that I needed in my project. I wanted to make an extension method for this but `DiscordClient._apiClient` is internal 😞.
- `Message.GuildId` was added to the specs of Discord on Sep 13, 2018 (<https://github.com/discordapp/discord-api-docs/pull/684>) and can be safely added.