### PR TITLE
Add GuildId to IDiscordMessage

### DIFF
--- a/Miki.Discord.Common/Models/IDiscordMessage.cs
+++ b/Miki.Discord.Common/Models/IDiscordMessage.cs
@@ -24,6 +24,11 @@ namespace Miki.Discord.Common
         /// </summary>
 		ulong ChannelId { get; }
 
+        /// <summary>
+        /// The guild this message was created in.
+        /// </summary>
+        ulong? GuildId { get; }
+
         IReadOnlyList<ulong> MentionedUserIds { get; }
 
         DateTimeOffset Timestamp { get; }

--- a/Miki.Discord/Internal/DiscordMessage.cs
+++ b/Miki.Discord/Internal/DiscordMessage.cs
@@ -45,7 +45,10 @@ namespace Miki.Discord.Internal
 		public ulong ChannelId
 			=> _packet.ChannelId;
 
-		public IReadOnlyList<ulong> MentionedUserIds
+        public ulong? GuildId
+            => _packet.GuildId;
+
+        public IReadOnlyList<ulong> MentionedUserIds
 			=> _packet.Mentions.Select(x => x.Id)
                 .ToList();
 


### PR DESCRIPTION
This was first in the PR https://github.com/Mikibot/Miki.Discord/pull/14. I closed it because  `DiscordClient._apiClient` is public now. But I kinda still want the GuildId in the IDiscordMessage.

I know it's possible to do `(message.Author as IDiscordGuildUser)?.GuildId` but getting a property is faster than boxing.