### PR TITLE
Fix for approaching Miki via DM

### DIFF
--- a/Miki.Discord/DiscordClient.cs
+++ b/Miki.Discord/DiscordClient.cs
@@ -185,8 +185,7 @@ the user without the guild ID. Use the cached client instead.");
         /// <inheritdoc/>
         public virtual async Task<IDiscordChannel> GetChannelAsync(ulong id, ulong? guildId = null)
         {
-            var channel = await cacheHandler.Channels.GetAsync(id, guildId);
-
+            DiscordChannelPacket channel = (guildId == null) ? (await cacheHandler.Channels.GetAsync(id)) : (await cacheHandler.Channels.GetAsync(id, guildId));
             return AbstractionHelpers.ResolveChannel(this, channel);
         }
 

--- a/Miki.Discord/DiscordClient.cs
+++ b/Miki.Discord/DiscordClient.cs
@@ -88,7 +88,7 @@ namespace Miki.Discord
         public virtual async Task<IDiscordTextChannel> CreateDMAsync(ulong userid)
         {
             var channel = await ApiClient.CreateDMChannelAsync(userid);
-            if(!(AbstractionHelpers.ResolveChannel(this, channel) is IDiscordTextChannel textChannel))
+            if(!(AbstractionHelpers.ResolveChannel(this, channel) is IDiscordTextChannel textChannel))             
             {
                 throw new InvalidDataException("DM channel was not a text channel");
             }
@@ -185,7 +185,9 @@ the user without the guild ID. Use the cached client instead.");
         /// <inheritdoc/>
         public virtual async Task<IDiscordChannel> GetChannelAsync(ulong id, ulong? guildId = null)
         {
-            DiscordChannelPacket channel = (guildId == null) ? (await cacheHandler.Channels.GetAsync(id)) : (await cacheHandler.Channels.GetAsync(id, guildId));
+            DiscordChannelPacket channel = (guildId == null) 
+                ? await cacheHandler.Channels.GetAsync(id) 
+                : await cacheHandler.Channels.GetAsync(id, guildId);
             return AbstractionHelpers.ResolveChannel(this, channel);
         }
 

--- a/Miki.Discord/Internal/Repositories/DiscordChannelCacheRepository.cs
+++ b/Miki.Discord/Internal/Repositories/DiscordChannelCacheRepository.cs
@@ -32,7 +32,7 @@ namespace Miki.Discord.Internal.Repositories
 
         protected override async ValueTask<DiscordChannelPacket> GetFromCacheAsync(params object[] id)
         {
-            if (id.Length == 1 || id[1] == null)
+            if (id.Length == 1)
             {
                 return await cacheClient.HashGetAsync<DiscordChannelPacket>(
                     CacheHelpers.ChannelsKey(), id[0].ToString());

--- a/Miki.Discord/Internal/Repositories/DiscordChannelCacheRepository.cs
+++ b/Miki.Discord/Internal/Repositories/DiscordChannelCacheRepository.cs
@@ -32,7 +32,7 @@ namespace Miki.Discord.Internal.Repositories
 
         protected override async ValueTask<DiscordChannelPacket> GetFromCacheAsync(params object[] id)
         {
-            if (id.Length == 1)
+            if (id.Length == 1 || id[1] == null)
             {
                 return await cacheClient.HashGetAsync<DiscordChannelPacket>(
                     CacheHelpers.ChannelsKey(), id[0].ToString());


### PR DESCRIPTION
(params object[] id) always passes an array of length 2, even when approaching Miki in DM. id[1] contains the Guild ID which will be null when talking to Miki, causing issues since the current check relies on the length of the array.